### PR TITLE
Implement basic Elo matchmaking system

### DIFF
--- a/calmproject2/Assets/_Project/Scripts/Matchmaking.meta
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e261c70a19d45919df9975032b979e8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/EloUtility.cs
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/EloUtility.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace SurvivalChaos
+{
+    /// <summary>
+    /// Simple Elo rating utilities for free-for-all matches.
+    /// </summary>
+    public static class EloUtility
+    {
+        /// <summary>
+        /// Calculates new ratings from current ratings and final placements.
+        /// Placement of 1 means first place.
+        /// </summary>
+        /// <param name="ratings">Current Elo ratings.</param>
+        /// <param name="placements">Final placements matching the ratings array.</param>
+        /// <param name="kFactor">K-factor used in the calculation.</param>
+        public static int[] UpdateAfterMatch(int[] ratings, int[] placements, int kFactor = 32)
+        {
+            int count = ratings.Length;
+            int[] newRatings = new int[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                double delta = 0;
+                for (int j = 0; j < count; j++)
+                {
+                    if (i == j) continue;
+
+                    double expected = 1.0 / (1.0 + Math.Pow(10.0, (ratings[j] - ratings[i]) / 400.0));
+                    double actual = Score(placements[i], placements[j]);
+                    delta += kFactor * (actual - expected);
+                }
+                newRatings[i] = ratings[i] + (int)Math.Round(delta);
+            }
+
+            return newRatings;
+        }
+
+        private static double Score(int placeA, int placeB)
+        {
+            if (placeA == placeB) return 0.5;
+            return placeA < placeB ? 1.0 : 0.0;
+        }
+    }
+}

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/EloUtility.cs.meta
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/EloUtility.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f1ac07fbdddb47988b068f501b15e87a

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs
@@ -1,0 +1,86 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace SurvivalChaos
+{
+    /// <summary>
+    /// Very simple Elo-based matchmaking for 4-player matches.
+    /// </summary>
+    public class MatchmakingManager : MonoBehaviour
+    {
+        public static MatchmakingManager Instance { get; private set; }
+
+        private readonly List<MatchmakingTicket> queue = new();
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private void OnEnable()
+        {
+            StartCoroutine(ProcessLoop());
+        }
+
+        /// <summary>
+        /// Adds a ticket to the matchmaking queue.
+        /// </summary>
+        public void Enqueue(MatchmakingTicket ticket)
+        {
+            if (ticket != null)
+                queue.Add(ticket);
+        }
+
+        private IEnumerator ProcessLoop()
+        {
+            var wait = new WaitForSeconds(1f);
+            while (true)
+            {
+                yield return wait;
+                ProcessQueue();
+            }
+        }
+
+        private void ProcessQueue()
+        {
+            if (queue.Count < 4)
+                return;
+
+            queue.Sort((a, b) => a.Elo.CompareTo(b.Elo));
+
+            for (int i = 0; i <= queue.Count - 4;)
+            {
+                var block = queue.GetRange(i, 4);
+                int maxElo = block.Max(t => t.Elo);
+                int minElo = block.Min(t => t.Elo);
+                int diff = maxElo - minElo;
+
+                bool allReady = block.All(t => t.CurrentTolerance >= diff);
+                if (allReady)
+                {
+                    queue.RemoveRange(i, 4);
+                    StartMatch(block);
+                }
+                else
+                {
+                    i++;
+                }
+            }
+        }
+
+        private void StartMatch(List<MatchmakingTicket> tickets)
+        {
+            List<PlayerInfo> players = tickets.Select(t => t.Player).ToList();
+            GameManager.Instance.StartGame(players);
+        }
+    }
+}

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs.meta
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a7eec601561642f99a8275e4d3fa48e7

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingTicket.cs
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingTicket.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace SurvivalChaos
+{
+    /// <summary>
+    /// Represents a player's entry in the matchmaking queue.
+    /// </summary>
+    public class MatchmakingTicket
+    {
+        public PlayerInfo Player { get; }
+        public int Elo { get; set; }
+        public DateTime QueuedAt { get; }
+
+        private const int BaseTolerance = 50;
+        private const int IncreaseIntervalSeconds = 10;
+        private const int IncreaseAmount = 25;
+
+        public MatchmakingTicket(PlayerInfo player, int elo)
+        {
+            Player = player;
+            Elo = elo;
+            QueuedAt = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Current Elo tolerance for this ticket.
+        /// </summary>
+        public int CurrentTolerance
+        {
+            get
+            {
+                double seconds = (DateTime.UtcNow - QueuedAt).TotalSeconds;
+                int increments = (int)(seconds / IncreaseIntervalSeconds);
+                return BaseTolerance + IncreaseAmount * increments;
+            }
+        }
+    }
+}

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingTicket.cs.meta
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingTicket.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9bacfecf027b4bd8ac5aedf68ce59239


### PR DESCRIPTION
## Summary
- implement simple Elo update method
- add `MatchmakingManager` for 4-player Elo matchmaking
- represent queued player with `MatchmakingTicket`

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bf4041a14832187889b93ad729ea0