### PR TITLE
Add more gameplay stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Survival Chaos Unity Starter
 
-This repository contains a bare-bones Unity project structure intended to recreate the core loop of *Survival Chaos*.  
-The project lives in **calmproject2/** and targets **Unity 2022.3 LTS** with the Universal Render Pipeline (URP).
+This repository provides a lightweight Unity framework inspired by the custom Warcraft III map *Survival Chaos*.  It is meant as a learning playground or starting point for a more complete strategy game.  All Unity content lives in **calmproject2/** and the project targets **Unity&nbsp;2022.3 LTS** using the Universal Render Pipeline (URP).
 
 ---
 
@@ -33,6 +32,22 @@ The starter includes minimal implementations of several gameplay systems:
 | **HeroManager** | Handles hero-summon cooldowns and instantiation. |
 | **SpecialWeaponManager** | Manages global-weapon cooldowns and firing. |
 | **EventBus** | Lightweight publish/subscribe utility that decouples all of the above systems. |
+| **MatchmakingManager** | Example implementation of a simple Elo-based 4-player queue. |
+
+### Multiplayer Matchmaking
+
+The sample project includes a very small **MatchmakingManager** and helper
+classes that implement an Elo-based queue for four-player matches. Every second
+the queue is sorted by rating, and groups whose rating spread falls within each
+player's growing tolerance are popped and handed off to `GameManager`.
+
+### Player Profiles & Statistics
+
+Persistent data for each player lives in the `User` class. It exposes methods
+to record match results, units produced or destroyed, gold spending and more.
+The class keeps running totals of gold and crystal earned, calculates win rate,
+tracks which races a player uses most often and stores damage or unit-count
+metrics for richer post-game analytics.
 
 ---
 
@@ -46,4 +61,4 @@ The starter includes minimal implementations of several gameplay systems:
 
 Basic unit combat has been implemented in `UnitController`. Attach the script to a prefab and assign a `UnitData` asset with `baseHP`, `baseAttack`, `attackCooldown`, and `attackRange` values. When spawned, units will look for the closest enemy within range and automatically deal damage every `attackCooldown` seconds. Units are destroyed when their health reaches zero.
 
-Happy modding!
+Enjoy experimenting and expanding upon the foundation provided here!

--- a/calmproject2/Assets/_Project/Scripts/Data/User.cs
+++ b/calmproject2/Assets/_Project/Scripts/Data/User.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+
+namespace SurvivalChaos
+{
+    /// <summary>
+    /// Persistent profile data for a player.
+    /// </summary>
+    [Serializable]
+    public class User
+    {
+        public string Name;
+        public int Rank;
+        public int TotalWins;
+        public float TotalPlaytime;             // Seconds
+        public float AveragePlaytimePerMatch;   // Seconds
+        public int Gold;        // Earned through gameplay
+        public int Crystal;     // Premium currency purchased with real money
+
+        // Extended gameplay analytics
+        public int TotalUnitsProduced { get; private set; }
+        public int TotalUnitsLost { get; private set; }
+        public int TotalUnitsKilled { get; private set; }
+        public float TotalDamageDealt { get; private set; }
+        public float TotalDamageReceived { get; private set; }
+        public int TotalGoldSpent { get; private set; }
+
+        public float LongestMatchDuration { get; private set; }
+        public float ShortestMatchDuration { get; private set; } = float.MaxValue;
+
+        // Running totals for analytics
+        public int TotalGoldAcquired { get; private set; }
+        public int TotalCrystalAcquired { get; private set; }
+
+        public int TotalMatches { get; private set; }
+
+        public int TotalLosses => TotalMatches - TotalWins;
+        public float WinRate => TotalMatches > 0 ? (float)TotalWins / TotalMatches : 0f;
+        public float AverageGoldPerMatch => TotalMatches > 0 ? (float)TotalGoldAcquired / TotalMatches : 0f;
+
+        // Track how often each race has been played
+        private readonly Dictionary<string, int> _racesPlayed = new Dictionary<string, int>();
+        public IReadOnlyDictionary<string, int> RacesPlayed => _racesPlayed;
+
+        /// <summary>
+        /// The race with the highest play count or null if none recorded.
+        /// </summary>
+        public string MostPlayedRace
+        {
+            get
+            {
+                string topRace = null;
+                int max = 0;
+                foreach (var pair in _racesPlayed)
+                {
+                    if (pair.Value > max)
+                    {
+                        topRace = pair.Key;
+                        max = pair.Value;
+                    }
+                }
+                return topRace;
+            }
+        }
+
+        public User(string name)
+        {
+            Name = name;
+            Rank = 0;
+            TotalWins = 0;
+            TotalPlaytime = 0f;
+            AveragePlaytimePerMatch = 0f;
+            Gold = 0;
+            Crystal = 0;
+            TotalGoldAcquired = 0;
+            TotalCrystalAcquired = 0;
+            TotalMatches = 0;
+
+            TotalUnitsProduced = 0;
+            TotalUnitsLost = 0;
+            TotalUnitsKilled = 0;
+            TotalDamageDealt = 0f;
+            TotalDamageReceived = 0f;
+            TotalGoldSpent = 0;
+            LongestMatchDuration = 0f;
+            ShortestMatchDuration = float.MaxValue;
+        }
+
+        /// <summary>
+        /// Records the result of a single match and updates aggregates.
+        /// </summary>
+        /// <param name="won">Whether the player won the match.</param>
+        /// <param name="durationSeconds">Length of the match in seconds.</param>
+        /// <param name="goldEarned">Gold earned from the match.</param>
+        /// <param name="race">Name of the race played.</param>
+        public void RecordMatch(bool won, float durationSeconds, int goldEarned, string race)
+        {
+            TotalMatches++;
+            if (won)
+                TotalWins++;
+
+            TotalPlaytime += durationSeconds;
+            AveragePlaytimePerMatch = TotalPlaytime / TotalMatches;
+            Gold += goldEarned;
+            TotalGoldAcquired += goldEarned;
+
+            if (durationSeconds > LongestMatchDuration)
+                LongestMatchDuration = durationSeconds;
+            if (durationSeconds < ShortestMatchDuration)
+                ShortestMatchDuration = durationSeconds;
+
+            if (!string.IsNullOrEmpty(race))
+            {
+                if (_racesPlayed.ContainsKey(race))
+                    _racesPlayed[race]++;
+                else
+                    _racesPlayed[race] = 1;
+            }
+        }
+
+        /// <summary>
+        /// Adds premium currency purchased by the player.
+        /// </summary>
+        public void AddCrystal(int amount)
+        {
+            if (amount > 0)
+            {
+                Crystal += amount;
+                TotalCrystalAcquired += amount;
+            }
+        }
+
+        /// <summary>
+        /// Tracks when the player spawns a unit.
+        /// </summary>
+        public void RecordUnitProduced()
+        {
+            TotalUnitsProduced++;
+        }
+
+        /// <summary>
+        /// Tracks a killed enemy unit.
+        /// </summary>
+        public void RecordUnitKill()
+        {
+            TotalUnitsKilled++;
+        }
+
+        /// <summary>
+        /// Tracks loss of one of the player's units.
+        /// </summary>
+        public void RecordUnitLost()
+        {
+            TotalUnitsLost++;
+        }
+
+        /// <summary>
+        /// Adds damage dealt by the player.
+        /// </summary>
+        public void AddDamageDealt(float amount)
+        {
+            if (amount > 0f)
+                TotalDamageDealt += amount;
+        }
+
+        /// <summary>
+        /// Adds damage received by the player.
+        /// </summary>
+        public void AddDamageReceived(float amount)
+        {
+            if (amount > 0f)
+                TotalDamageReceived += amount;
+        }
+
+        /// <summary>
+        /// Records gold spent on upgrades or purchases.
+        /// </summary>
+        public void RecordGoldSpent(int amount)
+        {
+            if (amount > 0)
+            {
+                TotalGoldSpent += amount;
+                if (Gold >= amount)
+                    Gold -= amount;
+            }
+        }
+    }
+}

--- a/calmproject2/Assets/_Project/Scripts/Data/User.cs.meta
+++ b/calmproject2/Assets/_Project/Scripts/Data/User.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b6e9316c481e4af0bdb6c59098803ac5

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking.meta
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e261c70a19d45919df9975032b979e8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/EloUtility.cs
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/EloUtility.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace SurvivalChaos
+{
+    /// <summary>
+    /// Simple Elo rating utilities for free-for-all matches.
+    /// </summary>
+    public static class EloUtility
+    {
+        /// <summary>
+        /// Calculates new ratings from current ratings and final placements.
+        /// Placement of 1 means first place.
+        /// </summary>
+        /// <param name="ratings">Current Elo ratings.</param>
+        /// <param name="placements">Final placements matching the ratings array.</param>
+        /// <param name="kFactor">K-factor used in the calculation.</param>
+        public static int[] UpdateAfterMatch(int[] ratings, int[] placements, int kFactor = 32)
+        {
+            int count = ratings.Length;
+            int[] newRatings = new int[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                double delta = 0;
+                for (int j = 0; j < count; j++)
+                {
+                    if (i == j) continue;
+
+                    double expected = 1.0 / (1.0 + Math.Pow(10.0, (ratings[j] - ratings[i]) / 400.0));
+                    double actual = Score(placements[i], placements[j]);
+                    delta += kFactor * (actual - expected);
+                }
+                newRatings[i] = ratings[i] + (int)Math.Round(delta);
+            }
+
+            return newRatings;
+        }
+
+        private static double Score(int placeA, int placeB)
+        {
+            if (placeA == placeB) return 0.5;
+            return placeA < placeB ? 1.0 : 0.0;
+        }
+    }
+}

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/EloUtility.cs.meta
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/EloUtility.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f1ac07fbdddb47988b068f501b15e87a

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs
@@ -1,0 +1,86 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace SurvivalChaos
+{
+    /// <summary>
+    /// Very simple Elo-based matchmaking for 4-player matches.
+    /// </summary>
+    public class MatchmakingManager : MonoBehaviour
+    {
+        public static MatchmakingManager Instance { get; private set; }
+
+        private readonly List<MatchmakingTicket> queue = new();
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private void OnEnable()
+        {
+            StartCoroutine(ProcessLoop());
+        }
+
+        /// <summary>
+        /// Adds a ticket to the matchmaking queue.
+        /// </summary>
+        public void Enqueue(MatchmakingTicket ticket)
+        {
+            if (ticket != null)
+                queue.Add(ticket);
+        }
+
+        private IEnumerator ProcessLoop()
+        {
+            var wait = new WaitForSeconds(1f);
+            while (true)
+            {
+                yield return wait;
+                ProcessQueue();
+            }
+        }
+
+        private void ProcessQueue()
+        {
+            if (queue.Count < 4)
+                return;
+
+            queue.Sort((a, b) => a.Elo.CompareTo(b.Elo));
+
+            for (int i = 0; i <= queue.Count - 4;)
+            {
+                var block = queue.GetRange(i, 4);
+                int maxElo = block.Max(t => t.Elo);
+                int minElo = block.Min(t => t.Elo);
+                int diff = maxElo - minElo;
+
+                bool allReady = block.All(t => t.CurrentTolerance >= diff);
+                if (allReady)
+                {
+                    queue.RemoveRange(i, 4);
+                    StartMatch(block);
+                }
+                else
+                {
+                    i++;
+                }
+            }
+        }
+
+        private void StartMatch(List<MatchmakingTicket> tickets)
+        {
+            List<PlayerInfo> players = tickets.Select(t => t.Player).ToList();
+            GameManager.Instance.StartGame(players);
+        }
+    }
+}

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs.meta
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a7eec601561642f99a8275e4d3fa48e7

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingTicket.cs
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingTicket.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace SurvivalChaos
+{
+    /// <summary>
+    /// Represents a player's entry in the matchmaking queue.
+    /// </summary>
+    public class MatchmakingTicket
+    {
+        public PlayerInfo Player { get; }
+        public int Elo { get; set; }
+        public DateTime QueuedAt { get; }
+
+        private const int BaseTolerance = 50;
+        private const int IncreaseIntervalSeconds = 10;
+        private const int IncreaseAmount = 25;
+
+        public MatchmakingTicket(PlayerInfo player, int elo)
+        {
+            Player = player;
+            Elo = elo;
+            QueuedAt = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Current Elo tolerance for this ticket.
+        /// </summary>
+        public int CurrentTolerance
+        {
+            get
+            {
+                double seconds = (DateTime.UtcNow - QueuedAt).TotalSeconds;
+                int increments = (int)(seconds / IncreaseIntervalSeconds);
+                return BaseTolerance + IncreaseAmount * increments;
+            }
+        }
+    }
+}

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingTicket.cs.meta
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingTicket.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9bacfecf027b4bd8ac5aedf68ce59239


### PR DESCRIPTION
## Summary
- describe player profile and analytics in README
- extend `User` class with expanded statistics like unit counts and damage totals

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bf4041a14832187889b93ad729ea0