### PR TITLE
Add chaos match type

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ classes that implement an Elo-based queue for four-player matches. Every second
 the queue is sorted by rating, and groups whose rating spread falls within each
 player's growing tolerance are popped and handed off to `GameManager`.
 
+Matchmaking supports two **match types**:
+ - **Normal** – each player keeps their chosen race.
+ - **Chaos** – races are randomly assigned when the match forms.
+
 
 ### Player Profiles & Statistics
 

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchType.cs
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchType.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace SurvivalChaos
+{
+    /// <summary>
+    /// Types of matchmaking that influence how player races are selected.
+    /// </summary>
+    public enum MatchType
+    {
+        /// <summary>Each player keeps the race they queued with.</summary>
+        Normal,
+
+        /// <summary>Races are randomised for all players once a match forms.</summary>
+        Chaos
+    }
+}

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchType.cs.meta
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1af63855595d4cbdbc18b4a642d29e47

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -11,6 +12,9 @@ namespace SurvivalChaos
     {
         // Singleton shortcut --------------------------------------------------
         public static MatchmakingManager Instance { get; private set; }
+
+        [Tooltip("How player races are chosen when a match forms.")]
+        public MatchType matchType = MatchType.Normal;
 
         // Tunables ------------------------------------------------------------
         private const int   PLAYERS_PER_MATCH   = 4;
@@ -55,8 +59,18 @@ namespace SurvivalChaos
                 {
                     // Build a Match
                     List<PlayerInfo> players = new(PLAYERS_PER_MATCH);
+                    Array races = Enum.GetValues(typeof(Race));
                     for (int p = 0; p < PLAYERS_PER_MATCH; ++p)
-                        players.Add(_queue[i + p].Player);
+                    {
+                        PlayerInfo original = _queue[i + p].Player;
+                        Race race = original.race;
+                        if (matchType == MatchType.Chaos)
+                        {
+                            int idx = UnityEngine.Random.Range(0, races.Length);
+                            race = (Race)races.GetValue(idx);
+                        }
+                        players.Add(new PlayerInfo(original.id, race, original.color));
+                    }
 
                     // Remove tickets from queue
                     _queue.RemoveRange(i, PLAYERS_PER_MATCH);


### PR DESCRIPTION
## Summary
- introduce `MatchType` enum
- allow `MatchmakingManager` to randomize races when in Chaos mode
- document match types in README

## Testing
- `git status --short`
- `which mcs`


------
https://chatgpt.com/codex/tasks/task_e_685d1bfb506c83219dc8c3700b4d6987