### PR TITLE
Improve matchmaking tolerance logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ The starter includes minimal implementations of several gameplay systems:
 
 The sample project includes a very small **MatchmakingManager** and helper
 classes that implement an Elo-based queue for four-player matches. Every second
-the queue is sorted by rating, and groups whose rating spread falls within each
-player's growing tolerance are popped and handed off to `GameManager`.
+the queue is sorted by rating, and groups whose rating spread falls within the
+smallest tolerance of the waiting players are popped and handed off to
+`GameManager`. Each ticket widens its own tolerance over time so longer-waiting
+players match more quickly without forcing global settings.
 
 Matchmaking supports two **match types**:
  - **Normal** – each player keeps their chosen race.

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs
@@ -13,14 +13,11 @@ public IReadOnlyList<MatchmakingTicket> QueueReadOnly      => _queue;
 public IReadOnlyCollection<Match>       ReadyMatchesReadOnly => _readyMatches;
 
         private const int PLAYERS_PER_MATCH = 4;
-        private const int START_TOLERANCE = 50;  // ±Elo
-        private const int TOLERANCE_STEP = 25;  // widens per scan
         private const float CHECK_INTERVAL = 1.0f;
 
         private readonly List<MatchmakingTicket> _queue = new();
         private readonly Queue<Match> _readyMatches = new();
 
-        private int _tolerance = START_TOLERANCE;
         private float _nextScan = 0f;
 
         private void Awake()
@@ -41,7 +38,11 @@ public IReadOnlyCollection<Match>       ReadyMatchesReadOnly => _readyMatches;
                 int min = _queue[i].Elo;
                 int max = _queue[i + PLAYERS_PER_MATCH - 1].Elo;
 
-                if (max - min <= _tolerance)
+                int tolerance = int.MaxValue;
+                for (int p = 0; p < PLAYERS_PER_MATCH; ++p)
+                    tolerance = System.Math.Min(tolerance, _queue[i + p].CurrentTolerance);
+
+                if (max - min <= tolerance)
                 {
                     var players = new List<PlayerInfo>(PLAYERS_PER_MATCH);
                     for (int p = 0; p < PLAYERS_PER_MATCH; ++p)
@@ -53,7 +54,6 @@ public IReadOnlyCollection<Match>       ReadyMatchesReadOnly => _readyMatches;
                 else
                     ++i;
             }
-            _tolerance += TOLERANCE_STEP;
         }
 
         // --------------------------- Public API -----------------------------


### PR DESCRIPTION
## Summary
- apply per-player tolerance when forming matches
- document updated matchmaking behaviour

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d27bc3bd0832187b28baa6032cc50