### PR TITLE
Improve matchmaking tolerance logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,13 @@ The starter includes minimal implementations of several gameplay systems:
 
 The sample project includes a very small **MatchmakingManager** and helper
 classes that implement an Elo-based queue for four-player matches. Every second
-the queue is sorted by rating, and groups whose rating spread falls within each
-player's growing tolerance are popped and handed off to `GameManager`.
+the queue is sorted by rating, and groups whose rating spread falls within the
+smallest tolerance of the waiting players are popped and handed off to
+`GameManager`. Each ticket widens its own tolerance over time so longer-waiting
+players match more quickly without forcing global settings. When a match starts
+it is tracked by `MatchManager` until completion. Duration is recorded and each
+player's `User` profile is updated before the result is logged to the in-memory
+`GameDatabase`.
 
 Matchmaking supports two **match types**:
  - **Normal** – each player keeps their chosen race.

--- a/calmproject2/Assets/_Project/Scripts/Core/MatchManager.cs
+++ b/calmproject2/Assets/_Project/Scripts/Core/MatchManager.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SurvivalChaos
+{
+    /// <summary>
+    /// Tracks matches that are in progress and finalises them when complete.
+    /// </summary>
+    public class MatchManager : MonoBehaviour
+    {
+        public static MatchManager Instance { get; private set; }
+
+        private class ActiveMatch
+        {
+            public Match Match;
+            public List<User> Profiles;
+        }
+
+        private readonly List<ActiveMatch> _active = new();
+        public IReadOnlyList<Match> ActiveMatches
+        {
+            get
+            {
+                var list = new List<Match>(_active.Count);
+                foreach (var am in _active) list.Add(am.Match);
+                return list;
+            }
+        }
+
+        private void Awake()
+        {
+            if (Instance == null) Instance = this;
+            else Destroy(gameObject);
+        }
+
+        /// <summary>Starts tracking a new match.</summary>
+        public void StartMatch(Match match, List<User> profiles)
+        {
+            if (match == null || profiles == null) return;
+            match.Start();
+            _active.Add(new ActiveMatch { Match = match, Profiles = profiles });
+        }
+
+        /// <summary>
+        /// Finishes an active match, updates user stats and logs it.
+        /// </summary>
+        public void FinishMatch(Match match, int[] placements, int[] goldEarned)
+        {
+            for (int i = 0; i < _active.Count; ++i)
+            {
+                if (_active[i].Match != match) continue;
+
+                match.Finish();
+                var am = _active[i];
+
+                int count = am.Profiles.Count;
+                int[] ratings = new int[count];
+                for (int p = 0; p < count; ++p)
+                    ratings[p] = am.Profiles[p].Elo;
+
+                if (placements != null && placements.Length == count)
+                {
+                    int[] newRatings = EloUtility.UpdateAfterMatch(ratings, placements);
+                    for (int p = 0; p < count; ++p)
+                        am.Profiles[p].ApplyNewElo(newRatings[p]);
+                }
+
+                for (int p = 0; p < count; ++p)
+                {
+                    bool won = placements != null && placements[p] == 1;
+                    int earned = goldEarned != null && goldEarned.Length > p ? goldEarned[p] : 0;
+                    am.Profiles[p].RecordMatch(won, match.DurationSeconds, earned, match.Players[p].race.ToString());
+                }
+
+                GameDatabase.Instance.LogMatch(match);
+                _active.RemoveAt(i);
+                break;
+            }
+        }
+    }
+}

--- a/calmproject2/Assets/_Project/Scripts/Core/MatchManager.cs.meta
+++ b/calmproject2/Assets/_Project/Scripts/Core/MatchManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e4f767a75dd74de89039ea34a3e43c93

--- a/calmproject2/Assets/_Project/Scripts/Data/GameDatabase.cs
+++ b/calmproject2/Assets/_Project/Scripts/Data/GameDatabase.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace SurvivalChaos
+{
+    /// <summary>
+    /// Simple in-memory database for storing completed match logs.
+    /// </summary>
+    public class GameDatabase
+    {
+        public static GameDatabase Instance { get; } = new GameDatabase();
+
+        public struct MatchLog
+        {
+            public IReadOnlyList<PlayerInfo> Players;
+            public DateTime StartedAt;
+            public DateTime EndedAt;
+            public float DurationSeconds;
+        }
+
+        private readonly List<MatchLog> _logs = new();
+        public IReadOnlyList<MatchLog> Logs => _logs;
+
+        public void LogMatch(Match match)
+        {
+            _logs.Add(new MatchLog
+            {
+                Players = match.Players,
+                StartedAt = match.StartedAt,
+                EndedAt = match.EndedAt ?? DateTime.UtcNow,
+                DurationSeconds = match.DurationSeconds
+            });
+        }
+    }
+}

--- a/calmproject2/Assets/_Project/Scripts/Data/GameDatabase.cs.meta
+++ b/calmproject2/Assets/_Project/Scripts/Data/GameDatabase.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: e821ffcbf1fdc954e8f82f49116b4a89
+guid: 914cc6e1cfcc46a59ae0996388d4c41e

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/LobbyDemo.cs
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/LobbyDemo.cs
@@ -68,16 +68,26 @@ public class LobbyDemo : MonoBehaviour
                 SetPlayState(p.profile, false);
         }
 
-       while (MatchmakingManager.Instance.TryDequeueReadyMatch(out Match match))
-{
-    Debug.Log($"[Lobby] Match ready with {match.Players.Count} players");
+        while (MatchmakingManager.Instance.TryDequeueReadyMatch(out Match match))
+        {
+            Debug.Log($"[Lobby] Match ready with {match.Players.Count} players");
 
-  // Tell the debug overlay that this one is now ‘in play’
-   var overlay = FindObjectOfType<MatchmakingDebugOverlay>();
-   if (overlay) overlay.MarkMatchAsPlaying(match);
+            // Build profile list for MatchManager
+            var profiles = new List<User>(match.Players.Count);
+            foreach (var pInfo in match.Players)
+            {
+                if (active.TryGetValue(pInfo.id, out LobbyUser lu))
+                    profiles.Add(lu.Profile);
+            }
 
-    // TODO: load gameplay scene & hand over match.Players
-}
+            // Register with MatchManager and overlay
+            var manager = FindObjectOfType<MatchManager>();
+            if (manager) manager.StartMatch(match, profiles);
+            var overlay = FindObjectOfType<MatchmakingDebugOverlay>();
+            if (overlay) overlay.MarkMatchAsPlaying(match);
+
+            // TODO: load gameplay scene & hand over match.Players
+        }
     }
 
     // ───────────────────────────────────────────── internal helpers

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/Match.cs
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/Match.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace SurvivalChaos
@@ -21,9 +22,29 @@ namespace SurvivalChaos
     {
         public IReadOnlyList<PlayerInfo> Players { get; }
 
+        public DateTime StartedAt { get; private set; }
+        public DateTime? EndedAt { get; private set; }
+
+        public float DurationSeconds
+            => (float)((EndedAt ?? DateTime.UtcNow) - StartedAt).TotalSeconds;
+
         public Match(List<PlayerInfo> players)
         {
             Players = players;
+        }
+
+        /// <summary>Marks the match as started.</summary>
+        public void Start()
+        {
+            StartedAt = DateTime.UtcNow;
+            EndedAt = null;
+        }
+
+        /// <summary>Marks the match as finished.</summary>
+        public void Finish()
+        {
+            if (EndedAt == null)
+                EndedAt = DateTime.UtcNow;
         }
     }
 }

--- a/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs
+++ b/calmproject2/Assets/_Project/Scripts/Matchmaking/MatchmakingManager.cs
@@ -13,14 +13,11 @@ public IReadOnlyList<MatchmakingTicket> QueueReadOnly      => _queue;
 public IReadOnlyCollection<Match>       ReadyMatchesReadOnly => _readyMatches;
 
         private const int PLAYERS_PER_MATCH = 4;
-        private const int START_TOLERANCE = 50;  // ±Elo
-        private const int TOLERANCE_STEP = 25;  // widens per scan
         private const float CHECK_INTERVAL = 1.0f;
 
         private readonly List<MatchmakingTicket> _queue = new();
         private readonly Queue<Match> _readyMatches = new();
 
-        private int _tolerance = START_TOLERANCE;
         private float _nextScan = 0f;
 
         private void Awake()
@@ -41,7 +38,11 @@ public IReadOnlyCollection<Match>       ReadyMatchesReadOnly => _readyMatches;
                 int min = _queue[i].Elo;
                 int max = _queue[i + PLAYERS_PER_MATCH - 1].Elo;
 
-                if (max - min <= _tolerance)
+                int tolerance = int.MaxValue;
+                for (int p = 0; p < PLAYERS_PER_MATCH; ++p)
+                    tolerance = System.Math.Min(tolerance, _queue[i + p].CurrentTolerance);
+
+                if (max - min <= tolerance)
                 {
                     var players = new List<PlayerInfo>(PLAYERS_PER_MATCH);
                     for (int p = 0; p < PLAYERS_PER_MATCH; ++p)
@@ -53,7 +54,6 @@ public IReadOnlyCollection<Match>       ReadyMatchesReadOnly => _readyMatches;
                 else
                     ++i;
             }
-            _tolerance += TOLERANCE_STEP;
         }
 
         // --------------------------- Public API -----------------------------


### PR DESCRIPTION
## Summary
- apply per-player tolerance when forming matches
- document updated matchmaking behaviour
- track active matches, update user profiles on match completion and log to an in-memory database

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d27bc3bd0832187b28baa6032cc50