### PR TITLE
Add UI Toolkit menus and controller

### DIFF
--- a/calmproject2/Assets/_Project/Resources/UI/MainMenu.uxml
+++ b/calmproject2/Assets/_Project/Resources/UI/MainMenu.uxml
@@ -1,0 +1,9 @@
+<engine:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:engine="UnityEngine.UIElements" xmlns:editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Assets/UI%20Toolkit/MainMenuStyle.uss?fileID=7433441132597879392&amp;guid=6786292436358c446bda00ed8d1b452b&amp;type=3#MainMenuStyle" />
+    <engine:VisualElement name="Container" style="flex-grow: 1; justify-content: flex-start; align-items: center;">
+        <engine:Label text="Main Menu&#10;" name="header2" class="header" />
+        <engine:Button text="Play" name="Button_Play" class="button" />
+        <engine:Button text="Settings" name="Button_Settings" class="button" />
+        <engine:Button text="Profile" name="Button_Profile" class="button" />
+    </engine:VisualElement>
+</engine:UXML>

--- a/calmproject2/Assets/_Project/Resources/UI/MainMenu.uxml.meta
+++ b/calmproject2/Assets/_Project/Resources/UI/MainMenu.uxml.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ad81fb01213e46f38b75b467f38f06d6

--- a/calmproject2/Assets/_Project/Resources/UI/ProfileMenu.uxml
+++ b/calmproject2/Assets/_Project/Resources/UI/ProfileMenu.uxml
@@ -1,0 +1,8 @@
+<engine:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:engine="UnityEngine.UIElements" xmlns:editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Assets/UI%20Toolkit/MainMenuStyle.uss?fileID=7433441132597879392&amp;guid=6786292436358c446bda00ed8d1b452b&amp;type=3#MainMenuStyle" />
+    <engine:VisualElement name="Container" style="flex-grow: 1; justify-content: flex-start; align-items: center;">
+        <engine:Label text="Profile" name="header2" class="header" />
+        <engine:Label text="Rank: " name="Label_Rank" class="header" />
+        <engine:Button text="Back" name="Button_Back" class="button" />
+    </engine:VisualElement>
+</engine:UXML>

--- a/calmproject2/Assets/_Project/Resources/UI/ProfileMenu.uxml.meta
+++ b/calmproject2/Assets/_Project/Resources/UI/ProfileMenu.uxml.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f6d4cc1c1cf445719f0edd7b5b890d38

--- a/calmproject2/Assets/_Project/Resources/UI/QueueMenu.uxml
+++ b/calmproject2/Assets/_Project/Resources/UI/QueueMenu.uxml
@@ -1,0 +1,9 @@
+<engine:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:engine="UnityEngine.UIElements" xmlns:editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Assets/UI%20Toolkit/MainMenuStyle.uss?fileID=7433441132597879392&amp;guid=6786292436358c446bda00ed8d1b452b&amp;type=3#MainMenuStyle" />
+    <engine:VisualElement name="Container" style="flex-grow: 1; justify-content: flex-start; align-items: center;">
+        <engine:Label text="Queue" name="header2" class="header" />
+        <engine:Button text="With Players" name="Button_QueuePlayers" class="button" />
+        <engine:Button text="With Bots" name="Button_QueueBots" class="button" />
+        <engine:Button text="Back" name="Button_Back" class="button" />
+    </engine:VisualElement>
+</engine:UXML>

--- a/calmproject2/Assets/_Project/Resources/UI/QueueMenu.uxml.meta
+++ b/calmproject2/Assets/_Project/Resources/UI/QueueMenu.uxml.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 22ff75d5b7f74079a12f9ad5e18ac511

--- a/calmproject2/Assets/_Project/Resources/UI/SettingsMenu.uxml
+++ b/calmproject2/Assets/_Project/Resources/UI/SettingsMenu.uxml
@@ -1,0 +1,7 @@
+<engine:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:engine="UnityEngine.UIElements" xmlns:editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Assets/UI%20Toolkit/MainMenuStyle.uss?fileID=7433441132597879392&amp;guid=6786292436358c446bda00ed8d1b452b&amp;type=3#MainMenuStyle" />
+    <engine:VisualElement name="Container" style="flex-grow: 1; justify-content: flex-start; align-items: center;">
+        <engine:Label text="Settings" name="header2" class="header" />
+        <engine:Button text="Back" name="Button_Back" class="button" />
+    </engine:VisualElement>
+</engine:UXML>

--- a/calmproject2/Assets/_Project/Resources/UI/SettingsMenu.uxml.meta
+++ b/calmproject2/Assets/_Project/Resources/UI/SettingsMenu.uxml.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 039d52801e824db29a75de87f4c03820

--- a/calmproject2/Assets/_Project/Scripts/UI/MainMenuController.cs
+++ b/calmproject2/Assets/_Project/Scripts/UI/MainMenuController.cs
@@ -1,0 +1,65 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+using SurvivalChaos;
+
+public class MainMenuController : MonoBehaviour
+{
+    private UIDocument _doc;
+    private VisualTreeAsset _mainMenu;
+    private VisualTreeAsset _queueMenu;
+    private VisualTreeAsset _settingsMenu;
+    private VisualTreeAsset _profileMenu;
+
+    private User _player;
+
+    private void Awake()
+    {
+        _doc = GetComponent<UIDocument>();
+        _mainMenu = Resources.Load<VisualTreeAsset>("UI/MainMenu");
+        _queueMenu = Resources.Load<VisualTreeAsset>("UI/QueueMenu");
+        _settingsMenu = Resources.Load<VisualTreeAsset>("UI/SettingsMenu");
+        _profileMenu = Resources.Load<VisualTreeAsset>("UI/ProfileMenu");
+
+        _player = new User("Player") { Rank = 1 };
+        ShowMainMenu();
+    }
+
+    private void ShowMainMenu()
+    {
+        _doc.visualTreeAsset = _mainMenu;
+        _doc.rootVisualElement.Q<Button>("Button_Play").clicked += ShowQueueMenu;
+        _doc.rootVisualElement.Q<Button>("Button_Settings").clicked += ShowSettingsMenu;
+        _doc.rootVisualElement.Q<Button>("Button_Profile").clicked += ShowProfileMenu;
+    }
+
+    private void ShowQueueMenu()
+    {
+        _doc.visualTreeAsset = _queueMenu;
+        _doc.rootVisualElement.Q<Button>("Button_QueuePlayers").clicked += QueueWithPlayers;
+        _doc.rootVisualElement.Q<Button>("Button_QueueBots").clicked += QueueWithBots;
+        _doc.rootVisualElement.Q<Button>("Button_Back").clicked += ShowMainMenu;
+    }
+
+    private void ShowSettingsMenu()
+    {
+        _doc.visualTreeAsset = _settingsMenu;
+        _doc.rootVisualElement.Q<Button>("Button_Back").clicked += ShowMainMenu;
+    }
+
+    private void ShowProfileMenu()
+    {
+        _doc.visualTreeAsset = _profileMenu;
+        _doc.rootVisualElement.Q<Label>("Label_Rank").text = $"Rank: {_player.Rank}";
+        _doc.rootVisualElement.Q<Button>("Button_Back").clicked += ShowMainMenu;
+    }
+
+    private void QueueWithPlayers()
+    {
+        Debug.Log("Queueing with players");
+    }
+
+    private void QueueWithBots()
+    {
+        Debug.Log("Queueing with bots");
+    }
+}

--- a/calmproject2/Assets/_Project/Scripts/UI/MainMenuController.cs.meta
+++ b/calmproject2/Assets/_Project/Scripts/UI/MainMenuController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e35a21c243cb4db085a81f565311814e


### PR DESCRIPTION
## Summary
- implement a new `MainMenuController` script that swaps UI Toolkit trees for Main Menu, Queue selection, Settings, and Profile
- duplicate existing main menu layout under `Resources/UI` and add queue, settings, and profile layouts
- include simple buttons to queue with players or bots and to navigate between menus
- profile screen displays the player's rank

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a18c169f48321894f28fb0c521f20